### PR TITLE
Fix Next.js dev startup by removing TypeScript dependency requirement

### DIFF
--- a/scroll-genius/.gitignore
+++ b/scroll-genius/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.DS_Store

--- a/scroll-genius/app/api/generate/route.js
+++ b/scroll-genius/app/api/generate/route.js
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { buildContainer } from "../../../lib/gtm";
 
-export async function POST(req: NextRequest) {
+export async function POST(req) {
   try {
     const body = await req.json();
     const {
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     });
 
     return NextResponse.json(json);
-  } catch (e:any) {
+  } catch (e) {
     return NextResponse.json({ error: e?.message || "Server error" }, { status: 500 });
   }
 }

--- a/scroll-genius/app/layout.jsx
+++ b/scroll-genius/app/layout.jsx
@@ -4,7 +4,7 @@ export const metadata = {
 };
 import "./globals.css";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body>

--- a/scroll-genius/app/page.jsx
+++ b/scroll-genius/app/page.jsx
@@ -1,16 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 
-type Payload = {
-  ga4MeasurementId: string;
-  eventName: string;
-  thresholds: string;
-  selectors: string;
-  spaFix: boolean;
-  ajaxForms: boolean;
-  premium: boolean;
-};
-
 const defaultThresholds = "25,50,75,100";
 
 export default function Page() {
@@ -28,14 +18,14 @@ export default function Page() {
   const [spaFix, setSpaFix] = useState(true);
   const [ajaxForms, setAjaxForms] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [toast, setToast] = useState<string>("");
+  const [toast, setToast] = useState("");
 
   const canGenerate = useMemo(
     () => ga4Id.trim().length > 0 && eventName.trim().length > 0,
     [ga4Id, eventName]
   );
 
-  const doUnlock = (code: string) => {
+  const doUnlock = (code) => {
     if (code.trim().toUpperCase() === "DEMO-PRO") {
       setPremium(true);
       localStorage.setItem("sg_premium", "1");
@@ -48,7 +38,7 @@ export default function Page() {
     }
   };
 
-  const download = (data: any, filename = "ScrollGenius_Container.json") => {
+  const download = (data, filename = "ScrollGenius_Container.json") => {
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -60,7 +50,7 @@ export default function Page() {
     if (!canGenerate || busy) return;
     setBusy(true);
     try {
-      const payload: Payload = {
+      const payload = {
         ga4MeasurementId: ga4Id.trim(),
         eventName: eventName.trim(),
         thresholds: premium ? (thresholds.trim() || defaultThresholds) : defaultThresholds,
@@ -74,7 +64,7 @@ export default function Page() {
       const json = await res.json();
       download(json);
       setToast("✅ GTM container generated");
-    } catch (e:any) {
+    } catch (e) {
       setToast("❌ " + (e.message || "Error"));
     } finally {
       setBusy(false);
@@ -182,7 +172,7 @@ export default function Page() {
   );
 }
 
-function UnlockForm({ onUnlock }:{ onUnlock:(code:string)=>void }) {
+function UnlockForm({ onUnlock }) {
   const [code, setCode] = useState("");
   return (
     <div style={{display:'flex', gap:8, marginTop:8}}>

--- a/scroll-genius/lib/gtm.js
+++ b/scroll-genius/lib/gtm.js
@@ -2,18 +2,20 @@ import { CORE_LISTENER_HTML, AJAX_LISTENER_HTML } from "./templates";
 
 /** A tiny ID generator for GTM objects (stable per run) */
 const idBase = Date.now().toString().slice(-6);
-const mkId = (n:number) => String(Number(idBase) + n);
+const mkId = (n) => String(Number(idBase) + n);
 
-/** Build a minimal-yet-valid GTM container JSON (exportFormatVersion:2) */
-export function buildContainer(opts: {
-  ga4Id: string;
-  eventName: string;
-  thresholds: string;
-  selectors: string;
-  spaFix: boolean;
-  ajaxForms: boolean;
-  premium: boolean;
-}) {
+/**
+ * Build a minimal-yet-valid GTM container JSON (exportFormatVersion:2)
+ * @param {Object} opts
+ * @param {string} opts.ga4Id
+ * @param {string} opts.eventName
+ * @param {string} opts.thresholds
+ * @param {string} opts.selectors
+ * @param {boolean} opts.spaFix
+ * @param {boolean} opts.ajaxForms
+ * @param {boolean} opts.premium
+ */
+export function buildContainer(opts) {
   const TR_INIT = mkId(1);        // DOM Ready trigger for core HTML
   const TR_CEVT = mkId(2);        // Custom event trigger (scroll thresholds)
   const TR_FORM = mkId(3);        // Custom event trigger (form success)
@@ -28,7 +30,7 @@ export function buildContainer(opts: {
   const exportFormatVersion = 2;
 
   // ---- TRIGGERS ----
-  const triggers:any[] = [
+  const triggers = [
     {
       "triggerId": TR_INIT,
       "name": "ScrollGenius – Init (DOM Ready)",
@@ -59,7 +61,7 @@ export function buildContainer(opts: {
   }
 
   // ---- VARIABLES ----
-  const variables:any[] = [
+  const variables = [
     {
       "variableId": VAR_SCROLL_PERCENT,
       "name": "DL – scroll_percent",
@@ -83,7 +85,7 @@ export function buildContainer(opts: {
   }
 
   // ---- TAGS ----
-  const tags:any[] = [
+  const tags = [
     // 1) Core Custom HTML listener (fires once on DOM_READY)
     {
       "tagId": T_HTML_CORE,
@@ -132,7 +134,7 @@ export function buildContainer(opts: {
   }
 
   // ---- CONTAINER WRAP ----
-  const container:any = {
+  const container = {
     "exportFormatVersion": exportFormatVersion,
     "containerVersion": {
       "tag": tags,
@@ -148,7 +150,7 @@ export function buildContainer(opts: {
 
   // Free mode guard: when not premium, always strip selectors and force default thresholds inside the HTML tag.
   if (!opts.premium) {
-    const htmlTag = container.containerVersion.tag.find((t:any)=>t.tagId===T_HTML_CORE);
+    const htmlTag = container.containerVersion.tag.find((t)=>t.tagId===T_HTML_CORE);
     if (htmlTag) {
       htmlTag.parameter[0].value = CORE_LISTENER_HTML("25,50,75,100", "", opts.spaFix).replace(/\n/g," ");
     }

--- a/scroll-genius/lib/templates.js
+++ b/scroll-genius/lib/templates.js
@@ -8,7 +8,7 @@
  *  {{SELECTORS}}  -> "#footer, .cookie"
  *  {{SPAFIX}}     -> "true" | "false"
  */
-export const CORE_LISTENER_HTML = (thresholdsCSV:string, selectorsCSV:string, spaFix:boolean) => `
+export const CORE_LISTENER_HTML = (thresholdsCSV, selectorsCSV, spaFix) => `
 <script>
 (function(){
   var THRESHOLDS = (${JSON.stringify(thresholdsCSV)} || "25,50,75,100")


### PR DESCRIPTION
## Summary
- convert the app, API route, and supporting library files from TypeScript to JavaScript so Next.js no longer attempts a failing TypeScript auto-install
- update helper code accordingly and add a project .gitignore to exclude build and dependency artifacts

## Testing
- npm run dev
- curl -s -X POST http://localhost:3000/api/generate


------
https://chatgpt.com/codex/tasks/task_e_68dc2866f7bc8323971611c15e6b1249